### PR TITLE
TOGA-related fixes + newer GCC compatibility

### DIFF
--- a/src/Matrix.c
+++ b/src/Matrix.c
@@ -179,6 +179,9 @@ bool LogoddMatrix__destroy(LogoddMatrix* self) {
  * @return success boolean.
  */
 bool LogoddMatrix__set(LogoddMatrix* self, size_t column, size_t row, LOGODD_T value) {
+  if (column >= self->num_columns || row >= self->num_rows) {
+    die("Invalid matrix access: %lux%lu[%lu][%lu]", self->num_columns, self->num_rows, column, row);
+  }
 	self->v[self->num_rows * column + row] = value;
   return true;
 }

--- a/src/Model.c
+++ b/src/Model.c
@@ -103,7 +103,16 @@ bool match_codon(struct HMM* hmm, Params* params, size_t index, Literal codon[3]
   State__init(match_codon, "match_codon", 3, codon, params->emission_table_64_LAMBDA);
   logv(4, "Match: %c%c%c", Literal__char(codon[0]), Literal__char(codon[1]), Literal__char(codon[2]));
   match_codon->custom = index;
-  State__init_uniform(insert_codon_codon, "insert_codon_codon", 3, params->emission_table_61_LAMBDA);
+  /* if this is the last codon in the exon, then set uniform (61 codons) emission probabilities for the last insert state 
+     as this would insert intronic codons in case of a splice site shift into the intron.
+     We do the same for the acceptor side. 
+    */
+/*  if (last) {
+     State__init_uniform(insert_codon_codon, "insert_codon_codon", 3, params->emission_table_61_UNIFORM);
+  }else{
+*/
+     State__init_uniform(insert_codon_codon, "insert_codon_codon", 3, params->emission_table_61_LAMBDA);
+//  }
   insert_codon_codon->custom = index;
   State__init_uniform(insert_1nt_codon, "insert_1nt_codon", 1, params->emission_table_4_UNIFORM);
   insert_1nt_codon->custom = index;
@@ -258,6 +267,19 @@ struct HMM* multi_exon(struct Params* params, struct Fasta* fasta, struct Profil
       logv(1, "reference[%i] has stop: %s", i, reference_has_stop ? "true" : "false");
     }
 
+    // in single exon mode, we should only assume that the given exon is a first exon, if the users sets the -f parameter
+    // otherwise, don't assume it is a first exon, even if this (internal) exon starts with an ATG
+    // hence, we set reference_has_start to false
+    // same for the last exon
+    if (reference_has_start && fasta->num_references == 1 && params->firstexon == false) {
+       reference_has_start = false;
+       logv(1, "NOTE: single exon mode and -f (first exon) not set: set reference_has_start to false\n");
+    }
+    if (reference_has_stop && fasta->num_references == 1 && params->lastexon == false) {
+       reference_has_stop = false;
+       logv(1, "NOTE: single exon mode and -l (last exon) not set: set reference_has_stop to false\n");
+    }
+
     // intron start
     struct State* intron_start;
     if (former_intron == NULL) {
@@ -309,7 +331,16 @@ struct HMM* multi_exon(struct Params* params, struct Fasta* fasta, struct Profil
     State__add_incoming(insert_1nt_acceptor,   params->nti_nti,    insert_1nt_acceptor);
 
     struct State* insert_codon_acceptor = HMM__new_state(hmm);
-    State__init_uniform(insert_codon_acceptor, "insert_codon_acceptor", 3, params->emission_table_61_LAMBDA);
+    /* this is the codon insertion state between the acceptor (or split codon) and the first match codon 
+       we set its emission probabilities to uniform (61 codons) as this would insert intronic codons in case of a splice site shift 
+    */
+    /*printf("create acc profile for %s\n", acceptors[i]->filename); */
+    if (strstr(acceptors[i]->filename, "equiprobable_acceptor.tsv")) 
+    	/* printf("--> uniform !! \n"); */
+    	State__init_uniform(insert_codon_acceptor, "insert_codon_acceptor", 3, params->emission_table_61_UNIFORM);
+    else
+    	State__init_uniform(insert_codon_acceptor, "insert_codon_acceptor", 3, params->emission_table_61_LAMBDA);
+    
     State__add_incoming(insert_codon_acceptor, params->i3_i1_acc,  insert_codon_acceptor);
 
     struct State* between_split_ins = HMM__new_state(hmm);

--- a/src/Profile.c
+++ b/src/Profile.c
@@ -33,7 +33,7 @@ bool Profile__read(struct Profile* self, char filename[]) {
     for (size_t i=0; i < LINELENGTH; i++) {
       assert(i < LINELENGTH);
 
-      char c = fgetc(file_descriptor);
+      int c = fgetc(file_descriptor);
 
       bool stop = false;
       switch (c) {
@@ -41,13 +41,14 @@ bool Profile__read(struct Profile* self, char filename[]) {
           line[i] = '\0';
           done = true;
           stop = true;
+          break;
         case '\n':
           line[i] = '\0';
           i=0;
           stop = true;
           break;
         default:
-          line[i] = c;
+          line[i] = (char)c;
       }
 
       if (stop) {
@@ -75,6 +76,9 @@ bool Profile__read(struct Profile* self, char filename[]) {
       if (lineno == 0) {
         // In a profile, num_literals of each emission_table will be const 1.
         keys[i] = Literal__from_char(token[0]);
+        if (i >= 4) {
+          die("Too many columns in the header ");
+        }
 
         token = strtok(NULL, DELIMITERS);
         i++;

--- a/src/Profile.c
+++ b/src/Profile.c
@@ -27,6 +27,8 @@ bool Profile__read(struct Profile* self, char filename[]) {
   
   bool done = false;
   size_t lineno = 0;
+  size_t num_keys = 0;
+  Literal keys[4];
   while (!done) {
     // fill the line
     char line[LINELENGTH] = "\0";
@@ -58,7 +60,6 @@ bool Profile__read(struct Profile* self, char filename[]) {
 
     size_t i=0;
     size_t line_offset = 0;
-    Literal keys[4];
     char* token = strtok(line, DELIMITERS);
     struct EmissionTable* etable;
     while (token != NULL) {
@@ -75,16 +76,23 @@ bool Profile__read(struct Profile* self, char filename[]) {
       // the first line looks like `A\tC\tG\tT\n'
       if (lineno == 0) {
         // In a profile, num_literals of each emission_table will be const 1.
-        keys[i] = Literal__from_char(token[0]);
         if (i >= 4) {
-          die("Too many columns in the header ");
+          die("Too many columns in the header");
         }
-
+        keys[i] = Literal__from_char(token[0]);
         token = strtok(NULL, DELIMITERS);
         i++;
+        num_keys++;
         continue;
       }
 
+
+      if (i >= num_keys) {
+          die(
+            "Too many columns in row %lu in file %s; expected %lu columns from the header, got at least %lu)", 
+            lineno, self->filename, num_keys, i
+          );
+      }
 
       if (i == 0) {
         etable = Profile__add_emission(self);


### PR DESCRIPTION
Older fixes by Michael from 2024 for TOGA2 compatibility:
* fixed behaviour in the presence of `-f`/`-l` flags; no default assumption of the CDS start if an exon starts with a zero phase ATG;
* equiprobable acceptor profile support

Fresh fixes from 04.2026 for newer GCC versions compatibility:
* boundary check in `LogoddMatrix__set()`;
* `Profile__read()` (`Profile.c`:
    * moved keys[] declaration;
    * header-body column number check